### PR TITLE
Fix for resillience msg + added 5s timer

### DIFF
--- a/app/views/callbacks/resilience_callbacks.py
+++ b/app/views/callbacks/resilience_callbacks.py
@@ -10,7 +10,6 @@ def register_resilience_callbacks(app):
         prevent_initial_call=False
     )
     def load_initial_resilience(session_user):
-        """Fetch system resilience score on initial load and session changes"""
         if not session_user:
             return ""
         
@@ -24,7 +23,7 @@ def register_resilience_callbacks(app):
         except Exception as e:
             return f"Error: {str(e)}"
 
-    # Second callback to trigger a manual resilience calculation when button is clicked
+    # Trigger a manual resilience recalculation when button is clicked
     @app.callback(
         [Output("resilience-recalculate-feedback", "children"),
          Output("resilience-update-trigger", "children")],
@@ -35,32 +34,40 @@ def register_resilience_callbacks(app):
         try:
             response = requests.get("http://127.0.0.1:8000/api/resilience")
             if response.status_code == 200:
-                # Show message and update trigger
                 return "✅ Recalculating...", str(n_clicks)
             return "❌ Failed to recalculate.", no_update
         except Exception as e:
             return f"⚠️ Error: {str(e)}", no_update
-    
-    # Third callback to update displayed resilience score when recalculation is triggered
+
+    # Update the resilience score and show confirmation
     @app.callback(
         [Output("system-resilience-score", "children", allow_duplicate=True),
-         Output("resilience-recalculate-feedback", "children", allow_duplicate=True)],
+         Output("resilience-recalculate-feedback", "children", allow_duplicate=True),
+         Output("resilience-feedback-clear-timer", "disabled", allow_duplicate=True)],
         Input("resilience-update-trigger", "children"),
         State("system-resilience-score", "children"),
-        prevent_initial_call=True  # This must be True when using allow_duplicate
+        prevent_initial_call=True
     )
     def update_resilience_on_recalculate(update_trigger, _):
-        """Update resilience score when manually triggered"""
         if not update_trigger:
-            return no_update, no_update
-            
-        try:      
+            return no_update, no_update, True
+
+        try:
             response = requests.get("http://localhost:8000/api/resilience")
             if response.status_code == 200:
                 data = response.json()
                 new_score = round(data["system_resilience_score"], 4)
                 score_text = f"System Resilience Score: {new_score}%"
-
-                return score_text, "✅ Resilience updated."
+                return score_text, "✅ Resilience updated.", False  # Enable the timer
         except Exception as e:
-            return f"Error: {str(e)}", no_update
+            return f"Error: {str(e)}", no_update, True
+
+    # Clear the message after a few seconds
+    @app.callback(
+        [Output("resilience-recalculate-feedback", "children", allow_duplicate=True),
+         Output("resilience-feedback-clear-timer", "disabled", allow_duplicate=True)],
+        Input("resilience-feedback-clear-timer", "n_intervals"),
+        prevent_initial_call=True
+    )
+    def clear_resilience_feedback(_):
+        return "", True

--- a/app/views/pages/sidebar.py
+++ b/app/views/pages/sidebar.py
@@ -29,18 +29,21 @@ def sidebar(session_user=None):
         
         # RECALCULATE RESILIENCE BUTTON
         nav_items.append(
-            dbc.Button("Recalculate Resilience", id="recalculate-resilience-btn", color="primary",
-                        className="mt-2", style={"position": "absolute", "bottom": "190px", "width": "80%"})
-        )
-        
-        # Resilience recalculation feedback
-        nav_items.append(
-            html.Div(id="resilience-recalculate-feedback", className="text-white mt-2", style={"fontSize": "0.9rem"})
+            html.Div([
+                dbc.Button("Recalculate Resilience", id="recalculate-resilience-btn", color="primary",
+                        className="mt-2", style={"width": "100%"}),
+                html.Div(id="resilience-recalculate-feedback", className="text-white mt-2", style={"fontSize": "0.9rem"})
+            ], style={"position": "absolute", "bottom": "190px", "width": "80%"})
         )
 
         # Hidden div for triggering resilience score updates
         nav_items.append(
             html.Div(id="resilience-update-trigger", style={"display": "none"})
+        )
+        
+        # Timer to auto-clear the feedback message
+        nav_items.append(
+            dcc.Interval(id="resilience-feedback-clear-timer", interval=4000, n_intervals=0, disabled=True)
         )
 
         # REFRESH NEO4J GRAPH BUTTON


### PR DESCRIPTION
There was a tiny bug in the sidebar where the "resilience recalculated" message was showing behind the reset button:
![image](https://github.com/user-attachments/assets/dcf699a3-592d-4e28-9f33-4b1b470dcd32)

So I adjusted the code so the message now shows below the recalculate button in the sidebar.
Also, it clears up after 5s so it doesn't stay there forever (: 
![image](https://github.com/user-attachments/assets/cd9d1e96-b6ed-40e1-bc3f-0731661f3da5)
